### PR TITLE
Sign PSBT view for signing outside nodeguard

### DIFF
--- a/extension/src/components/textarea.rs
+++ b/extension/src/components/textarea.rs
@@ -8,7 +8,7 @@ pub struct Props {
     pub id: Option<String>,
     pub disabled: Option<bool>,
     pub value: String,
-    pub onchange: Callback<Result<String>>,
+    pub onchange: Option<Callback<Result<String>>>,
     pub itype: Option<String>,
     pub placeholder: Option<String>,
 }
@@ -36,7 +36,9 @@ pub fn textarea(props: &Props) -> Html {
     } = props.clone();
 
     let oninput = Callback::from(move |input_event: InputEvent| {
-        onchange.emit(get_value_from_input_event(input_event));
+        if let Some(oc) = onchange.as_ref() {
+            oc.emit(get_value_from_input_event(input_event));
+        };
     });
 
     html! {

--- a/extension/src/features/approve_pasted_psbt.rs
+++ b/extension/src/features/approve_pasted_psbt.rs
@@ -1,57 +1,52 @@
 use crate::{
-    components::select::{Select, SelectItem},
+    components::{
+        select::{Select, SelectItem},
+        textarea::TextArea,
+    },
     context::UserContext,
-    paste_psbt,
-    switch::Route,
-    utils::{events::State, storage::LocalStorage},
-    OperationRequestData,
+    utils::{helpers::get_clipboard, storage::LocalStorage},
 };
 use anyhow::anyhow;
+use anyhow::Result;
 use signer::{
     psbt_details::PSBTDetails,
     signer::decode_psbt_and_sign,
     storage::{SettingsStorage, UserStorage},
 };
 use std::str::FromStr;
-use web_sys::window;
 use yew::prelude::*;
-use yew_router::prelude::{use_location, use_navigator};
+use yew_router::prelude::use_navigator;
 
-#[function_component(ApprovePSBT)]
-pub fn approve_psbt() -> Html {
+#[function_component(ApprovePastedPSBT)]
+pub fn approve_pasted_psbt() -> Html {
     let password = use_context::<UserContext>()
         .unwrap()
         .password
         .clone()
         .unwrap_or_default();
     let navigator = use_navigator().unwrap();
-    let location = use_location().unwrap();
-    let state = location.state::<State>().unwrap();
     let storage = UserStorage::read(LocalStorage::default());
     let default_wallet = storage.get_default_wallet();
     let selected_wallet = use_state(|| default_wallet);
     let error = use_state(String::default);
     let selected_wallet_value = (*selected_wallet).clone();
     let error_value = (*error).clone();
-    let default_value = &OperationRequestData::default();
-    let operation_data = state
-        .get_ref::<OperationRequestData>()
-        .unwrap_or(default_value);
     let disabled = password.is_empty();
+    let psbt = use_state(String::default);
+    let psbt_value = (*psbt).clone();
+    let signed_psbt = use_state(String::default);
+    let signed_psbt_value = (*signed_psbt).clone();
 
-    if operation_data.psbt.is_none() {
-        return html! {
-            <>
-                <h class="title">{"Approve PSBT"}</h>
-                <div>{"PSBT could not be parsed"}</div>
-            </>
-        };
-    }
+    let onchange_psbt = {
+        let psbt = psbt.clone();
+        Callback::from(move |value: Result<String>| {
+            let _ = value.map(|v| psbt.set(v));
+        })
+    };
 
     let onclick_save = {
-        let psbt = operation_data.psbt.clone().unwrap();
-        let navigator = navigator.clone();
         let selected_wallet_value = selected_wallet_value.clone();
+        let psbt = psbt.clone();
         Callback::from(move |_: MouseEvent| {
             if password.is_empty() {
                 return;
@@ -65,16 +60,10 @@ pub fn approve_psbt() -> Html {
                 .and_then(|wallet| {
                     decode_psbt_and_sign(&psbt, wallet, &password, settings_storage.get_network())
                         .map_err(|e| anyhow!("Error while signing PSBT {e}"))
-                })
-                .and_then(|signed_psbt| {
-                    paste_psbt(&signed_psbt).map_err(|_| anyhow!("Error while pasting PSBT"))
                 });
 
             match result {
-                Ok(_) => {
-                    navigator.push(&Route::Home);
-                    window().unwrap().close().unwrap();
-                }
+                Ok(p) => signed_psbt.set(p),
                 Err(e) => error.set(format!("{e}")),
             }
         })
@@ -88,37 +77,56 @@ pub fn approve_psbt() -> Html {
 
     let onclick_goback = { Callback::from(move |_: MouseEvent| navigator.back()) };
 
-    let psbt = operation_data.psbt.clone().unwrap();
+    let onclick_copy_psbt = {
+        let signed_psbt_value = signed_psbt_value.clone();
+        Callback::from(move |_: MouseEvent| {
+            let _ = get_clipboard().map(|c| c.write_text(&signed_psbt_value));
+        })
+    };
+
+    let copy_disabled = signed_psbt_value.is_empty();
     let items: Vec<SelectItem> = storage
         .wallets
         .iter()
         .map(|w| SelectItem::new(&w.name, &w.name))
         .collect();
-    let psbt = PSBTDetails::from_str(&psbt).unwrap_or_default();
-    let data = operation_data.clone();
+
+    let parsed_successfully = {
+        let psbt_parsed = PSBTDetails::from_str(&psbt);
+        match psbt_parsed {
+            Ok(psbt) => html! {
+                <div class="display-field">
+                    <strong>{"Tx Id:"}</strong>
+                    <span>{psbt.tx_id}</span>
+                </div>
+            },
+            Err(_) => {
+                html! {}
+            }
+        }
+    };
+
+    let signed_successfully = {
+        if signed_psbt_value.is_empty() {
+            html! {}
+        } else {
+            html! {
+                <>
+                    <TextArea value={signed_psbt_value} disabled={true} />
+                    <button disabled={copy_disabled} onclick={onclick_copy_psbt}>{"Copy signed PSBT"}</button>
+                </>
+            }
+        }
+    };
+
     html! {
         <>
             <h class="title">{"Approve PSBT"}</h>
-            <div class="display-field">
-                <strong>{"Tx Id:"}</strong>
-                <span>{psbt.tx_id}</span>
-            </div>
-            <div class="display-field">
-                <strong>{"Operation Type:"}</strong>
-                <span>{data.request_type.clone()}</span>
-            </div>
-            <div class="display-field">
-                <strong>{"Amount:"}</strong>
-                <span>{data.amount}</span>
-                <span>{"BTC"}</span>
-            </div>
-            <div class="display-field">
-                <strong>{"Fee:"}</strong>
-                <span>{psbt.fee}</span>
-                <span>{"SATS"}</span>
-            </div>
             <Select {onchange} items={items} default={selected_wallet_value}/>
+            <TextArea value={psbt_value} onchange={onchange_psbt} placeholder="Paste your PSBT here"/>
+            {parsed_successfully}
             <div class="error">{error_value}</div>
+            {signed_successfully}
             <div class="button-bar">
                 <button class="cancel" onclick={onclick_goback}>{"Go back"}</button>
                 <button disabled={disabled} onclick={onclick_save}>{"Sign"}</button>

--- a/extension/src/features/home.rs
+++ b/extension/src/features/home.rs
@@ -44,10 +44,17 @@ pub fn home() -> Html {
 
     let onclick_export = {
         let selected_wallet_value = selected_wallet_value.clone();
+        let navigator = navigator.clone();
         Callback::from(move |_: MouseEvent| {
             navigator.push(&Route::ExportXPUB {
                 wallet_name: selected_wallet_value.clone(),
             });
+        })
+    };
+
+    let onclick_sign_psbt = {
+        Callback::from(move |_: MouseEvent| {
+            navigator.push(&Route::ApprovePastedPSBT);
         })
     };
 
@@ -72,6 +79,7 @@ pub fn home() -> Html {
             <Select {onchange} items={items} default={selected_wallet_value}/>
             <button onclick={onclick_import}>{"Import another wallet"}</button>
             <button onclick={onclick_export}>{"Export XPUB"}</button>
+            <button onclick={onclick_sign_psbt}>{"Sign a PSBT"}</button>
             <button onclick={onclick_settings}>{"Settings"}</button>
         </>
     }

--- a/extension/src/features/import_from_xprv.rs
+++ b/extension/src/features/import_from_xprv.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::components::text_input::TextInput;
 use crate::components::textarea::TextArea;
 use crate::features::input_password_modal::InputPasswordModal;
@@ -22,6 +25,7 @@ pub fn import_from_xprv() -> Html {
     let derivation_value = (*derivation).clone();
     let wallet_name_value = (*wallet_name).clone();
     let error_value = (*error).clone();
+    let storage = Rc::new(RefCell::new(UserStorage::read(LocalStorage::default())));
 
     let onclick = {
         let xprv = xprv_value.clone();
@@ -29,13 +33,13 @@ pub fn import_from_xprv() -> Html {
         let wallet_name = wallet_name_value.clone();
         let error = error.clone();
         let popup_visible = popup_visible.clone();
+        let storage = storage.clone();
         Callback::from(move |_: MouseEvent| {
-            let storage = UserStorage::read(LocalStorage::default());
             if wallet_name.is_empty() {
                 error.set("Wallet name is mandatory".into());
             }
 
-            if storage.get_wallet_ref(&wallet_name).is_some() {
+            if storage.borrow().get_wallet_ref(&wallet_name).is_some() {
                 error.set("There is already a wallet with that name".into());
                 return;
             }
@@ -74,7 +78,6 @@ pub fn import_from_xprv() -> Html {
         let derivation = derivation_value.clone();
         let popup_visible = popup_visible.clone();
         Callback::from(move |password: String| {
-            let mut storage = UserStorage::read(LocalStorage::default());
             let mut wallet = Wallet::default();
 
             if wallet_name_value.is_empty() {
@@ -88,8 +91,9 @@ pub fn import_from_xprv() -> Html {
                 error.set("Error while parsing secret".to_string());
             }
 
-            storage.wallets.push(wallet);
-            let stored = storage.save();
+            let mut s = storage.borrow_mut();
+            s.wallets.push(wallet);
+            let stored = s.save();
 
             if stored.is_err() {
                 error.set("Error while storing wallet".to_string());

--- a/extension/src/features/mod.rs
+++ b/extension/src/features/mod.rs
@@ -1,3 +1,4 @@
+pub mod approve_pasted_psbt;
 pub mod approve_psbt;
 pub mod create_account;
 pub mod export_xpub;

--- a/extension/src/features/settings.rs
+++ b/extension/src/features/settings.rs
@@ -1,5 +1,5 @@
 use signer::{storage::SettingsStorage, Network};
-use std::str::FromStr;
+use std::{cell::RefCell, str::FromStr};
 use yew::prelude::*;
 use yew_router::prelude::use_navigator;
 
@@ -11,9 +11,9 @@ use crate::{
 
 #[function_component(Settings)]
 pub fn settings() -> Html {
-    let storage = SettingsStorage::read(LocalStorage::default());
+    let storage = RefCell::new(SettingsStorage::read(LocalStorage::default()));
     let navigator = use_navigator().unwrap();
-    let network = use_state(|| storage.get_network());
+    let network = use_state(|| storage.borrow().get_network());
     let error = use_state(String::new);
     let network_value = *network;
     let error_value = (*error).clone();
@@ -25,9 +25,9 @@ pub fn settings() -> Html {
 
     let onclick_save = {
         Callback::from(move |_| {
-            let mut storage = SettingsStorage::read(LocalStorage::default());
-            storage.set_network(&network_value.to_string());
-            let stored = storage.save();
+            let mut s = storage.borrow_mut();
+            s.set_network(&network_value.to_string());
+            let stored = s.save();
 
             if stored.is_err() {
                 error.set("Unable to save settings".to_string());

--- a/extension/src/switch.rs
+++ b/extension/src/switch.rs
@@ -1,7 +1,8 @@
 use crate::features::{
-    approve_psbt::ApprovePSBT, create_account::CreateAccount, export_xpub::ExportXPUB,
-    generate_seed::GenerateSeed, home::Home, import_from_seed::ImportFromSeed,
-    import_from_xprv::ImportFromXprv, import_wallet::ImportWallet, settings::Settings,
+    approve_pasted_psbt::ApprovePastedPSBT, approve_psbt::ApprovePSBT,
+    create_account::CreateAccount, export_xpub::ExportXPUB, generate_seed::GenerateSeed,
+    home::Home, import_from_seed::ImportFromSeed, import_from_xprv::ImportFromXprv,
+    import_wallet::ImportWallet, settings::Settings,
 };
 use yew::{function_component, html, Html};
 use yew_router::{prelude::use_navigator, Routable, Switch};
@@ -18,6 +19,8 @@ pub enum Route {
     ImportWallet,
     #[at("/approve")]
     ApprovePSBT,
+    #[at("/approvepasted")]
+    ApprovePastedPSBT,
     #[at("/exportxpub/:wallet_name")]
     ExportXPUB { wallet_name: String },
     #[at("/settings")]
@@ -58,6 +61,7 @@ pub fn switch(routes: Route) -> Html {
             html! { <Switch<ImportWalletRoute> render={switch_import_wallets}/> }
         }
         Route::ApprovePSBT => html! { <ApprovePSBT/> },
+        Route::ApprovePastedPSBT => html! { <ApprovePastedPSBT/> },
         Route::ExportXPUB { wallet_name } => html! { <ExportXPUB wallet_name={wallet_name}/> },
         Route::Settings => html! { <Settings /> },
         Route::NotFound => html! { <Redirect /> },


### PR DESCRIPTION
To be merged after https://github.com/Elenpay/Nodeguards-Companion/pull/11

This PR is about a view to directly paste a PSBT into the extension and sign it with one of the keys, rather than making the extension detect the psbt in the page. This is because sometimes we want to sign a PSBT that is not in nodeguard and the user has to set up Sparrow instead